### PR TITLE
fix：買うものリストとスケジュールの機能調整・リファクタリング、買うものリストのストレージ上限到達に際するエラーハンドリングを追加.

### DIFF
--- a/src/components/korekau/KorekauBased.tsx
+++ b/src/components/korekau/KorekauBased.tsx
@@ -31,7 +31,7 @@ export const KorekauBased = memo(() => {
     }, []);
 
     return (
-        <section>
+        <section className="korekauSection">
             <details style={formAccordionStyle}>
                 <summary>買うものを新たに登録する</summary>
                 <KorekauForm />

--- a/src/components/korekau/hooks/useCheckJSONByteSize.ts
+++ b/src/components/korekau/hooks/useCheckJSONByteSize.ts
@@ -1,0 +1,24 @@
+/**
+ * Uncaught DOMException: Failed to execute 'setItem' on 'Storage': Setting the value of '*' exceeded the quota.
+ * localStorage が容量上限に達した場合のエラーハンドリングのカスタムフック
+*/
+
+export const useCheckJSONByteSize = () => {
+    const checkJSONByteSize = (jsonStr: string, limitByte?: number) => {
+        const isSmartPhone_Tablet: boolean = window.matchMedia("(max-width: 700px)").matches;
+
+        /* limitByte：1000b -> 1kb, 1000kb -> 1mb（1000000b）*/
+        const storageLimit: number = limitByte ?? isSmartPhone_Tablet ? 2500000 : 5000000; // スマホ・タブレットでは2.5mb、PCでは5mbがデフォルト値
+
+        /* TextEncoderを使用してUTF-8バイト配列に変換 */
+        const encoder = new TextEncoder();
+        const utf8Array = encoder.encode(jsonStr);
+
+        if (utf8Array.byteLength > storageLimit) {
+            alert(`登録リストのファイルサイズが${Math.floor(utf8Array.byteLength).toLocaleString()}バイトで、ストレージ上限（${Math.floor(storageLimit).toLocaleString()}バイト）を超過するため登録できません。\n画像の登録を減らすなどファイルサイズの軽量化を行ってください。\nこのメッセージを閉じた後に再読み込みします。`);
+            location.reload();
+        }
+    }
+
+    return { checkJSONByteSize }
+}

--- a/src/components/korekau/hooks/useKorekauFormClosed.ts
+++ b/src/components/korekau/hooks/useKorekauFormClosed.ts
@@ -1,0 +1,10 @@
+export const useKorekauFormClosed = () => {
+    const korekauFormClosed: () => void = () => {
+        const korekauSectionForm: HTMLDetailsElement | null = document.querySelector('.korekauSection details');
+        if (korekauSectionForm?.open) {
+            korekauSectionForm.removeAttribute('open');
+        }
+    }
+
+    return { korekauFormClosed }
+}

--- a/src/components/korekau/hooks/useRegiKorekauItem.ts
+++ b/src/components/korekau/hooks/useRegiKorekauItem.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { useAtom } from "jotai";
 import { korekauAtom, korekauItemsLocalStorageAtom } from "../../../ts/korekau-atom";
-import { korekauItemsType } from "../ts/korekau";
+import { itemCategoryType, korekauItemsType } from "../ts/korekau";
 import { localstorageLabel_KorekauItems } from "../../../ts/korekau-localstorageLabel";
 
 export const useRegiKorekauItem = () => {
@@ -10,10 +10,10 @@ export const useRegiKorekauItem = () => {
 
     const localstorageLabelKorekauItems: string = localstorageLabel_KorekauItems;
 
-    const regiKorekauItem: (itemName: string, itemNumber: number, itemCategory: string, itemPriority: boolean, itemImgMemo?: string, itemImgSrc?: string) => void = (
+    const regiKorekauItem: (itemName: string, itemNumber: number, itemCategory: itemCategoryType, itemPriority: boolean, itemImgMemo?: string, itemImgSrc?: string) => void = (
         itemName: string,
         itemNumber: number,
-        itemCategory: string,
+        itemCategory: itemCategoryType,
         itemPriority: boolean,
         itemImgMemo?: string,
         itemImgSrc?: string

--- a/src/components/korekau/hooks/useUpdateKorekauItems.ts
+++ b/src/components/korekau/hooks/useUpdateKorekauItems.ts
@@ -1,8 +1,9 @@
 import { useAtom } from "jotai";
 import { korekauAtom, korekauItemsLocalStorageAtom } from "../../../ts/korekau-atom";
-import { korekauItemsType } from "../ts/korekau";
+import { itemCategoryType, korekauItemsType } from "../ts/korekau";
 import { localstorageLabel_KorekauItems } from "../../../ts/korekau-localstorageLabel";
 import { useGetTargetIndexForCtrlItems } from "./useGetTargetIndexForCtrlItems";
+import { useCheckJSONByteSize } from "./useCheckJSONByteSize";
 
 export const useUpdateKorekauItems = () => {
     const [korekauLists, setKorekauLists] = useAtom(korekauAtom);
@@ -11,12 +12,13 @@ export const useUpdateKorekauItems = () => {
     const localstorageLabelKorekauItems: string = localstorageLabel_KorekauItems;
 
     const { getTargetIndexForCtrlItems } = useGetTargetIndexForCtrlItems();
+    const { checkJSONByteSize } = useCheckJSONByteSize();
 
-    const updateKorekauItems: (KorekauItemList: korekauItemsType, updateItemName: string, updateItemNumber: number, updateItemCategory: string, updateItemPriority: boolean, itemImgMemo?: string, itemImgSrc?: string) => void = (
+    const updateKorekauItems: (KorekauItemList: korekauItemsType, updateItemName: string, updateItemNumber: number, updateItemCategory: itemCategoryType, updateItemPriority: boolean, itemImgMemo?: string, itemImgSrc?: string) => void = (
         KorekauItemList: korekauItemsType,
         updateItemName: string,
         updateItemNumber: number,
-        updateItemCategory: string,
+        updateItemCategory: itemCategoryType,
         updateItemPriority: boolean,
         itemImgMemo?: string,
         itemImgSrc?: string
@@ -38,6 +40,7 @@ export const useUpdateKorekauItems = () => {
         if (updateItemName.length > 0) {
             setKorekauLists((_prevKorekauLists) => shallowCopy);
             /* ---------------- localStorage 関連の処理（更新）---------------- */
+            checkJSONByteSize(JSON.stringify([...shallowCopy])); // localStorage のストレージ上限チェック
             setLocalstorage((_prevLocalStorage) => shallowCopy);
             localStorage.setItem(localstorageLabelKorekauItems, JSON.stringify([...shallowCopy]));
         }

--- a/src/components/korekau/ts/korekau.ts
+++ b/src/components/korekau/ts/korekau.ts
@@ -1,8 +1,10 @@
+export type itemCategoryType = 'food_drink' | 'utils' | 'family' | 'myself' | 'others';
+
 export type korekauItemsType = {
     uuid: string; // key へ渡すための固有の識別子（uuid：Universally Unique Identifier）。useRegiKorekauItem.ts にて生成 
     itemName: string;
     itemNumber: number;
-    itemCategory: string;
+    itemCategory: itemCategoryType;
     itemPriority: boolean;
     itemMemo?: string;
     itemImg?: string;

--- a/src/components/schedule/todoItems/TodoForm.tsx
+++ b/src/components/schedule/todoItems/TodoForm.tsx
@@ -33,6 +33,7 @@ export const TodoForm: FC<todoFormType> = (props) => {
         setTodoContent((_prevTodoContent) => '');
         setStartTime((_prevStartTime) => '');
         setFinishTime((_prevFinishTime) => '');
+        setTimeout(() => scrollTop()); // buttonのクリックイベントでスクロールトップしないので回避策として疑似的な遅延処理
     }
 
     useEffect(() => resetStates(), [todoID]); // 前月や次月に移動するたびに入力欄を初期化

--- a/src/components/schedule/todoItems/TodoList.tsx
+++ b/src/components/schedule/todoItems/TodoList.tsx
@@ -21,7 +21,7 @@ export const TodoList = ({ todoID }: { todoID: string }) => {
         <>
             {todoMemo.length > 0 &&
                 <ul className={todoStyle.todoLists}>
-                    {todoMemo.map((todoItem, i) => (
+                    {todoMemo.map(todoItem => (
                         <Fragment key={todoItem.uuid}>
                             {/* yyyy/MM/dd が一致した場合 */}
                             {todoItem.todoID === todoID ?
@@ -35,7 +35,12 @@ export const TodoList = ({ todoID }: { todoID: string }) => {
                                             {todoItem.startTime && <span>開始時刻：{todoItem.startTime}</span>}
                                             {todoItem.finishTime && <span>終了時刻：{todoItem.finishTime}</span>}
                                         </div> :
-                                        <p className={todoStyle.isMobileNotice}>予定{i + 1}</p>
+                                        <p className={todoStyle.isMobileNotice}>
+                                            {todoItem.todoContent.length > 8 ?
+                                                <>{todoItem.todoContent.slice(0, 8)}...</> :
+                                                <>{todoItem.todoContent}</>
+                                            }
+                                        </p>
                                     }
                                     <TodoItems
                                         todoItem={todoItem}

--- a/src/components/schedule/todoItems/hooks/useUpdateTodoItem.ts
+++ b/src/components/schedule/todoItems/hooks/useUpdateTodoItem.ts
@@ -2,12 +2,15 @@ import { todoItemType } from "../ts/todoItemType";
 import { useAtom } from "jotai";
 import { todoMemoAtom, todoMemoLocalStorageAtom } from "../../../../ts/calendar-atom";
 import { localstorageLabelName } from "../../../../ts/calendar-localstorageLabel";
+import { useCheckJSONByteSize } from "../../../korekau/hooks/useCheckJSONByteSize";
 
 export const useUpdateTodoItem = () => {
     const [, setLocalstorage] = useAtom(todoMemoLocalStorageAtom); // 更新関数のみ使用
     const [todoMemo, setTodoMemo] = useAtom(todoMemoAtom);
 
     const localstorageLabel = localstorageLabelName;
+
+    const { checkJSONByteSize } = useCheckJSONByteSize();
 
     /* ToDo の更新 */
     const updateTodoItem: (todoID: string, uuid: string, todoContent: string, startTime: string, finishTime: string) => void = (
@@ -39,6 +42,8 @@ export const useUpdateTodoItem = () => {
             // setTodoMemo((_prevTodoMemo) => shallowCopy);
             setTodoMemo((_prevTodoMemo) => [...exceptRemoveTodoItems, updateTodoList]);
             /* ---------------- localStorage 関連の処理（更新）---------------- */
+            checkJSONByteSize(JSON.stringify([...exceptRemoveTodoItems, updateTodoList])); // localStorage のストレージ上限チェック
+
             // setLocalstorage((_prevLocalStorage) => shallowCopy);
             // localStorage.setItem(localstorageLabel, JSON.stringify([...shallowCopy]));
             setLocalstorage((_prevLocalStorage) => [...exceptRemoveTodoItems, updateTodoList]);

--- a/src/utils/ImportJsonData.tsx
+++ b/src/utils/ImportJsonData.tsx
@@ -3,6 +3,7 @@ import { korekauItemsType } from "../components/korekau/ts/korekau";
 import { useAtom } from "jotai";
 import { korekauAtom, korekauItemsLocalStorageAtom } from "../ts/korekau-atom";
 import { localstorageLabel_KorekauItems } from "../ts/korekau-localstorageLabel";
+import { useCheckJSONByteSize } from "../components/korekau/hooks/useCheckJSONByteSize";
 
 export const ImportJsonData = memo(() => {
     const [korekauLists, setKorekauLists] = useAtom(korekauAtom);
@@ -11,6 +12,8 @@ export const ImportJsonData = memo(() => {
     const localstorageLabelKorekauItems: string = localstorageLabel_KorekauItems;
 
     const fileAccept: string = 'application/json';
+
+    const { checkJSONByteSize } = useCheckJSONByteSize();
 
     const inputJsonData = (fileElm: HTMLInputElement) => {
         if (fileElm.files && fileElm.files[0].name !== 'korekauitems.json') return; // 所定のファイル名でない場合は早期終了 
@@ -24,6 +27,7 @@ export const ImportJsonData = memo(() => {
             const newKorekauItems: korekauItemsType[] = [...korekauLists, ...inputKorekauItemsJsonData];
             setKorekauLists((_prevKorekauLists) => newKorekauItems);
             /* ---------------- localStorage 関連の処理（登録）---------------- */
+            checkJSONByteSize(JSON.stringify(newKorekauItems)); // localStorage のストレージ上限チェック
             setLocalstorage((_prevLocalstorage) => newKorekauItems);
             localStorage.setItem(localstorageLabelKorekauItems, JSON.stringify(newKorekauItems));
             location.reload();


### PR DESCRIPTION
- 買うものリストの機能調整・リファクタリング
  - `useKorekauFormClosed.ts`<br>新規登録後に登録フォームを閉じる処理
  - `useRegiKorekauItem.ts`, `useUpdateKorekauItems.ts`, `korekau.ts`<br>買うものリストのカテゴリーをユニオンの文字列型に変更
  - `KorekauForm.tsx`<br>上記の機能追加とリファクタリング、フォームの`submit`イベントの関数化（`handleFormSubmit`）を実施<br>テキストエリアのスタイル微調整
- スケジュールの機能調整・リファクタリング
  - `TodoList.tsx` <br>スケジュール表への登録イベント（予定）名の表示（8文字以上の場合は抜粋表示）
  - `TodoForm.tsx` <br>`submit`イベントにスクロールトップを追加
- 買うものリストのストレージ上限到達に際するエラーハンドリングを追加
  - `src/components/korekau/hooks/useCheckJSONByteSize.ts` 
    - `ImportJsonData.tsx`<br>ファイル読み込み時
    - `src/components/schedule/todoItems/hooks/useUpdateTodoItem.ts`<br>スケジュール更新時
    - `src/components/korekau/hooks/useUpdateKorekauItems.ts`<br>買うものリスト更新時