### PR TITLE
fix：買うものリストの新規登録時のストレージ上限設定の実装、アップロード画像に関する表記の調整.

### DIFF
--- a/src/components/korekau/hooks/useRegiKorekauItem.ts
+++ b/src/components/korekau/hooks/useRegiKorekauItem.ts
@@ -3,12 +3,15 @@ import { useAtom } from "jotai";
 import { korekauAtom, korekauItemsLocalStorageAtom } from "../../../ts/korekau-atom";
 import { itemCategoryType, korekauItemsType } from "../ts/korekau";
 import { localstorageLabel_KorekauItems } from "../../../ts/korekau-localstorageLabel";
+import { useCheckJSONByteSize } from './useCheckJSONByteSize';
 
 export const useRegiKorekauItem = () => {
     const [korekauLists, setKorekauLists] = useAtom(korekauAtom);
     const [, setLocalstorage] = useAtom(korekauItemsLocalStorageAtom);
 
     const localstorageLabelKorekauItems: string = localstorageLabel_KorekauItems;
+
+    const { checkJSONByteSize } = useCheckJSONByteSize();
 
     const regiKorekauItem: (itemName: string, itemNumber: number, itemCategory: itemCategoryType, itemPriority: boolean, itemImgMemo?: string, itemImgSrc?: string) => void = (
         itemName: string,
@@ -31,6 +34,7 @@ export const useRegiKorekauItem = () => {
         if (itemName.length > 0) {
             setKorekauLists((_prevKorekauLists) => [...korekauLists, newKorekauItems]);
             /* ---------------- localStorage 関連の処理（登録）---------------- */
+            checkJSONByteSize(JSON.stringify([...korekauLists, newKorekauItems])); // localStorage のストレージ上限チェック
             setLocalstorage((_prevLocalStorage) => [...korekauLists, newKorekauItems]);
             localStorage.setItem(localstorageLabelKorekauItems, JSON.stringify([...korekauLists, newKorekauItems]));
         }


### PR DESCRIPTION
- 買うものリストの新規登録時のストレージ上限設定の実装
  - `src/components/korekau/hooks/useRegiKorekauItem.ts`<br>新規登録時の上限設定ストッパーの記述漏れを修正
- アップロード画像に関する表記の調整
  - `src/utils/UploadImgItem.tsx`<br>一度アップロードしたあと、`input[type="file"]`のプレースホルダーに以前アップロードした画像名（`file.name`）が表示されるので、エフェクトフックを用いて非表示にし、再度アップロードする際にはプレースホルダーを表示する仕様に調整