### PR TITLE
fix: ゴミ出し日の登録時における曜日設定と買うものリストの参考画像の登録処理に関する修正.

### DIFF
--- a/src/components/trash/utils/TrashForm.tsx
+++ b/src/components/trash/utils/TrashForm.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { ChangeEvent, memo, useState } from "react";
+import { ChangeEvent, memo, useRef, useState } from "react";
 import { trashType } from "../ts/trash";
 import { useRegiTrashDate } from "../hooks/useRegiTrashDate";
 import { useUpdateTrashDate } from "../hooks/useUpdateTrashDate";
@@ -8,9 +8,12 @@ import { useTargetElsRemoveClass } from "../../../hooks/useTargetElsRemoveClass"
 import { useHandleFormEntries } from "../../../hooks/useHandleFormEntries";
 
 export const TrashForm = memo(({ trashDateList }: { trashDateList?: trashType }) => {
+    const selectRef = useRef<HTMLSelectElement | null>(null);
+    const dayValue: number = selectRef.current !== null ? parseInt(selectRef.current?.value) : 1;
+
     const initTrashData: trashType = {
         uuid: trashDateList ? trashDateList.uuid : '001',
-        day: trashDateList ? trashDateList.day : 1,
+        day: trashDateList ? trashDateList.day : dayValue,
         trashDate: trashDateList ? trashDateList.trashDate : ''
     }
     const [trashData, setTrashData] = useState<trashType>(initTrashData);
@@ -36,7 +39,7 @@ export const TrashForm = memo(({ trashDateList }: { trashDateList?: trashType })
         }}>
             <div className="formBlock">
                 <label className="formLabel">曜日</label>
-                <select name="daySelect" id="day" onChange={(e: ChangeEvent<HTMLSelectElement>) => handleFormEntries<trashType>(e, trashData, setTrashData)}>
+                <select name="daySelect" id="day" ref={selectRef} onChange={(e: ChangeEvent<HTMLSelectElement>) => handleFormEntries<trashType>(e, trashData, setTrashData)}>
                     <option value="1">（月）</option>
                     <option value="2">（火）</option>
                     <option value="3">（水）</option>

--- a/src/utils/UploadImgItem.tsx
+++ b/src/utils/UploadImgItem.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, memo, useEffect } from "react";
+import { memo, SyntheticEvent, useEffect } from "react";
 import { korekauItemsType } from "../components/korekau/ts/korekau";
 import { useAtom } from "jotai";
 import { korekauAtom } from "../ts/korekau-atom";
@@ -14,7 +14,7 @@ export const UploadImgItem = memo(({ props }: { props: UploadImgItemType }) => {
     const handleItemImgSrc: (value: string) => void = (value: string) => {
         const newKorekauItem: korekauItemsType = {
             ...korekauItem,
-            itemImg: korekauItem ? korekauItem.itemImg : value
+            itemImg: value
         }
         setKorekauItem(newKorekauItem);
     }
@@ -23,7 +23,9 @@ export const UploadImgItem = memo(({ props }: { props: UploadImgItemType }) => {
 
     const fileAccept: string[] = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp']; // input[type="file"] で指定可能な mineType
 
-    const uploadImgView: (fileElm: HTMLInputElement) => void = (fileElm: HTMLInputElement) => {
+    const uploadImgView: (fileElmEve: SyntheticEvent<HTMLInputElement>) => void = (fileElmEve: SyntheticEvent<HTMLInputElement>) => {
+        const fileElm: HTMLInputElement = fileElmEve.currentTarget;
+
         // 画像アップロードの取り消しを行った場合は画像を画面から削除  
         if (fileElm.files?.length === 0) {
             handleItemImgSrc('');
@@ -78,7 +80,7 @@ export const UploadImgItem = memo(({ props }: { props: UploadImgItemType }) => {
             <input
                 type="file"
                 accept={`${[...fileAccept]}`}
-                onChange={(fileElm: ChangeEvent<HTMLInputElement>) => uploadImgView(fileElm.currentTarget)}
+                onChange={uploadImgView}
                 id="itemImgSrc"
             />
             {korekauItem.itemImg && <img src={korekauItem.itemImg} />}


### PR DESCRIPTION
- ゴミ出し日の登録時における曜日設定
`src/components/trash/utils/TrashForm.tsx`<br>`ref`を用いてリアルDOM（`select`）の内容（選択肢：`value`）を取得
- 買うものリストの参考画像の登録処理に関する修正
`src/utils/UploadImgItem.tsx`<br>登録または編集時に参照画像が読み込まれない及び登録されない事象が発生したので以下のように既存ステートに関する記述を排除して修正
```diff
- itemImg: korekauItem ? korekauItem.itemImg : value
+ itemImg: value // いまさっき選択（操作）した画像データを反映
```