### PR TITLE
fix: 買うものリストの参照画像の登録及び編集時の状態管理の不具合を修正.

### DIFF
--- a/src/components/korekau/utils/KorekauForm.tsx
+++ b/src/components/korekau/utils/KorekauForm.tsx
@@ -17,7 +17,7 @@ export const KorekauForm = memo(({ KorekauItemList }: { KorekauItemList?: koreka
         itemCategory: KorekauItemList ? KorekauItemList.itemCategory : 'food_drink',
         itemPriority: KorekauItemList ? KorekauItemList.itemPriority : false,
         itemMemo: '',
-        itemImg: KorekauItemList ? KorekauItemList.itemImg : ''
+        itemImg: ''
     }
     const [korekauItem, setKorekauItem] = useState<korekauItemsType>(initKorekauItem);
 
@@ -71,7 +71,8 @@ export const KorekauForm = memo(({ KorekauItemList }: { KorekauItemList?: koreka
                     <label className="formLabel">商品画像（※1MB以下）</label>
                     <UploadImgItem props={{
                         korekauItem: korekauItem,
-                        setKorekauItem: setKorekauItem
+                        setKorekauItem: setKorekauItem,
+                        KorekauItemList: KorekauItemList
                     }} />
                 </div>
             </div>
@@ -113,7 +114,7 @@ export const KorekauForm = memo(({ KorekauItemList }: { KorekauItemList?: koreka
             <div className={KorekauItemList ? 'formFlexBox' : undefined}>
                 <input type="submit"
                     value={KorekauItemList ? '再登録' : '登録'}
-                    disabled={(korekauItem.itemName.length <= 0 && Number(korekauItem.itemNumber) <= 0)} />
+                    disabled={korekauItem.itemName.length === 0 || Number(korekauItem.itemNumber) === 0} />
                 {KorekauItemList &&
                     <input type="button" className="editerCloseBtn"
                         value={'戻る'}

--- a/src/components/korekau/utils/PartKorekauItemsImg.tsx
+++ b/src/components/korekau/utils/PartKorekauItemsImg.tsx
@@ -6,7 +6,7 @@ export const PartKorekauItemsImg = memo(({ korekauList }: { korekauList: korekau
     return (
         <KorekauDetails>
             <summary><span className="material-symbols-outlined">mms</span>参照画像</summary>
-            <figure className="itemThumbnail"><img src={korekauList.itemImg} alt={`${korekauList.itemName}の画像`} /></figure>
+            <figure className="itemThumbnail"><img src={korekauList.itemImg} alt={`${korekauList.itemName}の参照画像`} /></figure>
         </KorekauDetails>
     );
 });


### PR DESCRIPTION
- 買うものリストの参照画像の登録及び編集時の状態管理の不具合を修正
  - `src/components/korekau/utils/KorekauForm.tsx`<br>買うものリストの初期値（`initKorekauItem`）の修正（画像パスを空文字で固定）
  - `src/components/korekau/utils/PartKorekauItemsImg.tsx`<br>`alt`テキストの修正
  - `src/utils/UploadImgItem.tsx`<br>リファクタリング及び画像の取り回しを修正
    - `itemImgSrc`<br>`KorekauItemList`と`korekauItem`の有無に応じた画像パス文字列を返却
    - `inputImgSrcRef`<br>リアルDOMの`img`を`ref`操作に変更し、従来仕様（`useEffect`フックと専用メソッド）を排除
    - `const [resetImgSrc, setResetImgSrc] = useState<boolean>(false);`<br>各種ボタンのクリックイベントに応じた画像描画用の真偽値ステートを用意