### PR TITLE
fix: jsonファイル読み込み時のID重複による買うものリストの編集不能状態の解消・修正.

### DIFF
--- a/src/components/korekau/hooks/useUpdateKorekauItems.ts
+++ b/src/components/korekau/hooks/useUpdateKorekauItems.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from "uuid";
 import { useAtom } from "jotai";
 import { korekauAtom, korekauItemsLocalStorageAtom } from "../../../ts/korekau-atom";
 import { korekauItemsType } from "../ts/korekau";
@@ -22,10 +23,16 @@ export const useUpdateKorekauItems = () => {
             }
         }).filter((korekauItem): korekauItem is number => typeof korekauItem !== 'undefined');
 
-        // `with`メソッドを用いて非破壊的に更新要素の置換処理を実施（置換対象アイテムのインデックス位置で置換）
-        const updateKorekauLists: korekauItemsType[] = korekauLists.with(targetIndex[0], updateKorekauItem);
+        // 新たなIDを付与しないと（どれか一つでも更新処理を行うと）json読み込み時にIDが重複して編集作業など操作不能に陥る
+        const addNewId_updateKorekauItem: korekauItemsType = {
+            ...updateKorekauItem,
+            uuid: uuidv4() // 新たなIDを付与して重複を防止
+        }
 
-        if (updateKorekauItem.itemName.length > 0) {
+        // `with`メソッドを用いて非破壊的に更新要素の置換処理を実施（置換対象アイテムのインデックス位置で置換）
+        const updateKorekauLists: korekauItemsType[] = korekauLists.with(targetIndex[0], addNewId_updateKorekauItem);
+
+        if (addNewId_updateKorekauItem.itemName.length > 0) {
             setKorekauLists(updateKorekauLists);
             /* ---------------- localStorage 関連の処理（更新）---------------- */
             checkJSONByteSize(JSON.stringify(updateKorekauLists)); // localStorage のストレージ上限チェック


### PR DESCRIPTION
-  jsonファイル読み込み時のID重複による買うものリストの編集不能状態の解消・修正
    - `src/components/korekau/hooks/useUpdateKorekauItems.ts`
    新たなIDを付与しないと（どれか一つでも更新処理を行うと）json読み込み時にIDが重複して編集作業など操作不能に陥るので`uuid`でIDを新規付与して処理を進める内容に変更