### PR TITLE
fix: スマホ閲覧時に編集フォームの下部が見切れる問題の対応ver2 | より厳密にスタイル調整.

### DIFF
--- a/src/components/korekau/utils/KorekauItemEditer.tsx
+++ b/src/components/korekau/utils/KorekauItemEditer.tsx
@@ -14,7 +14,7 @@ export const KorekauItemEditer = memo(({ props }: { props: itemEditerType }) => 
 
     return (
         <div className={`${classNameStr} overscroll-contain`}>
-            <div className="max-[640px]:overflow-y-scroll">
+            <div className="max-[640px]:overflow-y-scroll max-[640px]:h-full">
                 <div className="p-[1em] shadow-[0_0_8px_rgba(0,0,0,.25)_inset] bg-white mb-[1em] rounded flex flex-row flex-wrap items-center gap-[1em]">
                     <KorekauItemIcons category={category} />
                     <p className="w-[80%] wrap-anywhere">{korekauList.itemName}<span className="mx-[1em] text-[#59b835]">×{korekauList.itemNumber}</span>の内容を編集</p>


### PR DESCRIPTION
- スマホ閲覧時に編集フォームの下部が見切れる問題の対応ver2 | より厳密にスタイル調整
  - `src/components/korekau/utils/KorekauItemEditer.tsx`