### PR TITLE
fix: コンテンツナビゲーションメニューの透過エフェクトが完全位置表示だったので追従表示変更.

### DIFF
--- a/src/utils/ContentViewer.tsx
+++ b/src/utils/ContentViewer.tsx
@@ -44,7 +44,7 @@ export const ContentViewer = memo(() => {
 
     return (
         <>
-            <div className="absolute content-[''] left-0 bottom-0 w-full h-[calc(100vh/7)] bg-[linear-gradient(to_right,white,transparent_8%)] pointer-events-none z-9 lg:hidden">&nbsp;</div>
+            <div className="fixed content-[''] left-0 bottom-0 w-full h-[calc(100vh/7)] bg-[linear-gradient(to_right,white,transparent_8%)] pointer-events-none z-9 lg:hidden">&nbsp;</div>
             <nav className="bg-[rgba(255,255,255,.5)] w-full backdrop-blur-xl shadow-[0_0_4px_rgba(0,0,0,.25)] rounded-[1.5em_0_0_0] overflow-x-scroll fixed bottom-0 left-1/2 -translate-x-1/2 z-1 lg:bg-[#fff6df] lg:max-w-232 lg:shadow-none lg:rounded lg:bottom-auto lg:top-[6em] lg:overflow-x-auto">
                 <div className="flex justify-between gap-4 p-4 py-6 w-[140vw] lg:w-auto lg:py-4">
                     {navListsLabel.map((label, i) => (


### PR DESCRIPTION
- コンテンツナビゲーションメニューの透過エフェクトが完全位置表示だったので追従表示変更
  - `src/utils/ContentViewer.tsx`